### PR TITLE
import swagger file into editor.swagger.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # api.bambora.com
 Bambora API designs
 
-Most of the designs are written in Swagger. You can view the designs in a nice interactive editor by taking the content of the swagger.yaml files and pasting it in the swagger editor: http://editor.swagger.io/
+Most of the designs are written in Swagger. You can view the designs in the nice interactive swagger editor: http://editor.swagger.io/#/?import=https://raw.githubusercontent.com/bambora/api.bambora.com/master/payments-swagger.yaml


### PR DESCRIPTION
link directly to the master swagger file, no need to copy
the content of the swagger file after the repository was
made public
